### PR TITLE
runner: add 16GB swap file to avoid OOM

### DIFF
--- a/disk-config.nix
+++ b/disk-config.nix
@@ -1,4 +1,3 @@
-# Example to create a bios compatible gpt partition
 { lib, ... }:
 {
   disko.devices = {
@@ -22,6 +21,12 @@
               format = "vfat";
               mountpoint = "/boot";
             };
+          };
+          swap = {
+            size = "16G";
+            content = {
+              type = "swap";
+              discardPolicy = "both";
           };
           root = {
             name = "root";

--- a/runner.nix
+++ b/runner.nix
@@ -40,6 +40,17 @@
     pkgs.nebula
   ];
 
+  # Set a 16GB swap file to avoid some OOM
+  # Hopefully we can remove this on larger runners
+  {
+    swapDevices = [
+      {
+        device = "/swapfile";
+        size = 16*1024;  # 16GB
+      }
+    ];
+  }
+
   # Use authorized keys supplied at runtime from the deployment command
   users.users.root.openssh.authorizedKeys.keys =
     let


### PR DESCRIPTION
Mirrors the setup here: https://github.com/bitcoin/bitcoin/blob/e8f72aefd20049eac81b150e7f0d33709acd18ed/.cirrus.yml#L54

Hopefully we can remove this once we move to larger runners...